### PR TITLE
enable Gippet2023 to be indexed by Global Biotic Interactions

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,41 @@
+# This workflow will review a GloBI indexed dataset.
+# For more information see: https://globalbioticinteractions.org
+
+name: GloBI review by Elton
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+  schedule:
+    - cron: "0 0 * * 1"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: download review script
+        run: curl --silent -L "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/check-dataset.sh" > check-dataset.sh
+      - name: download network compiler script
+        run: |
+          curl --silent -L "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/compile-network.sh" > compile-network.sh
+          chmod +x compile-network.sh
+      - name: review dataset
+        run: bash check-dataset.sh "${GITHUB_REPOSITORY}"
+      - name: Share review report
+        uses: actions/upload-artifact@v3
+        with:
+          name: review-report
+          path: |
+            README.txt
+            datasets/
+            index.*
+            indexed-*
+            review*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.elton/
+add_travis_artifact_upload_keys.sh
+datasets/

--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ Supplementary data
 **Dataset S4.** R files allowing replication of the ensemble model performed to predict environmental suitability for *L. fulica*. This .Rdata object contains the cleaned and thinned GBIF occurrences for L. fulica presence and background (i.e., occurrences of Stylommatophora mollusks); the R script necessary to prepare data and run models; the R script necessary to prepare data and test differences in human density between L. fulica occurrences (native and invasive) and background occurrences.
 
 **Dataset S5.** Number of Instagram users referencing *L. fulica* as pets per country and total number of Instagram users per country (source: napoleoncat.com).
+
+## Indexing
+
+[![GloBI Review by Elton](../../actions/workflows/review.yml/badge.svg)](../../actions/workflows/review.yml) [![GloBI](https://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:JGippet/Gippet2023_GiantLandSnails&refutes=true&refutes=false)](https://globalbioticinteractions.org/?accordingTo=globi:JGippet/Gippet2023_GiantLandSnails)
+
+These supplementary data were configured to be indexed by Global Biotic Interactions (GloBI, https://globalbioticinteractions.org) as they related to: 
+
+Gippet, J.M.W., Bates, O.K., Moulin, J. et al. The global risk of infectious disease emergence from giant land snail invasion and pet trade. Parasites Vectors 16, 363 (2023). https://doi.org/10.1186/s13071-023-06000-y
+

--- a/globi.json
+++ b/globi.json
@@ -12,7 +12,7 @@
     "dcterms:bibliographicCitation" : "Gippet, J.M.W., Bates, O.K., Moulin, J. et al. The global risk of infectious disease emergence from giant land snail invasion and pet trade. Parasites Vectors 16, 363 (2023). https://doi.org/10.1186/s13071-023-06000-y",
     "delimiter" : ";",
     "interactionTypeName": "parasiteOf",
-    "interactionTypeId", "http://purl.obolibrary.org/obo/RO_0002444",
+    "interactionTypeId": "http://purl.obolibrary.org/obo/RO_0002444",
     "headerRowCount" : 1,
     "null" : [ "" ],
     "tableSchema" : {

--- a/globi.json
+++ b/globi.json
@@ -1,0 +1,101 @@
+{
+  "@context" : [ "http://www.w3.org/ns/csvw", {
+    "@language" : "en"
+  } ],
+  "rdfs:comment" : [ "inspired by https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/" ],
+  "tables" : [ {
+    "@context" : [ "http://www.w3.org/ns/csvw", {
+      "@language" : "en"
+    } ],
+    "rdfs:comment" : [ "inspired by https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/" ],
+    "url" : "TableS2_Gippet2023_Lfulica_pathogensList.csv",
+    "dcterms:bibliographicCitation" : "Gippet, J.M.W., Bates, O.K., Moulin, J. et al. The global risk of infectious disease emergence from giant land snail invasion and pet trade. Parasites Vectors 16, 363 (2023). https://doi.org/10.1186/s13071-023-06000-y",
+    "delimiter" : ";",
+    "interactionTypeName": "parasiteOf",
+    "interactionTypeId", "http://purl.obolibrary.org/obo/RO_0002444",
+    "headerRowCount" : 1,
+    "null" : [ "" ],
+    "tableSchema" : {
+      "columns" : [ {
+        "name" : "sourceTaxonName",
+        "titles" : "ParasiteSpecies",
+        "datatype" : "string"
+      }, {
+        "name" : "Nbstudies",
+        "titles" : "Nbstudies",
+        "datatype" : "string"
+      }, {
+        "name" : "Type",
+        "titles" : "Type",
+        "datatype" : "string"
+      }, {
+        "name" : "speciesLevel",
+        "titles" : "speciesLevel",
+        "datatype" : "string"
+      }, {
+        "name" : "pathogen",
+        "titles" : "pathogen",
+        "datatype" : "string"
+      } ]
+    }
+  }, {
+    "@context" : [ "http://www.w3.org/ns/csvw", {
+      "@language" : "en"
+    } ],
+    "rdfs:comment" : [ "inspired by https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/" ],
+    "url" : "TableS3_Gippet2023_Association_pathogens_hosts.csv",
+    "dcterms:bibliographicCitation" : "Gippet, J.M.W., Bates, O.K., Moulin, J. et al. The global risk of infectious disease emergence from giant land snail invasion and pet trade. Parasites Vectors 16, 363 (2023). https://doi.org/10.1186/s13071-023-06000-y",
+    "delimiter" : ",",
+    "interactionTypeName": "parasiteOf",
+    "interactionTypeId": "http://purl.obolibrary.org/obo/RO_0002444",
+    "headerRowCount" : 1,
+    "null" : [ "" ],
+    "tableSchema" : {
+      "columns" : [ {
+        "name" : "sourceTaxonName",
+        "titles" : "parasite",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonName",
+        "titles" : "host_harmonized",
+        "datatype" : "string"
+      }, {
+        "name" : "freq",
+        "titles" : "freq",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonPhylumName",
+        "titles" : "host_phylum",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonClassName",
+        "titles" : "host_class",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonOrderName",
+        "titles" : "host_order",
+        "datatype" : "string"
+      }, {
+        "name" : "targetTaxonFamilyName",
+        "titles" : "host_family",
+        "datatype" : "string"
+      }, {
+        "name" : "parasite_type",
+        "titles" : "parasite_type",
+        "datatype" : "string"
+      }, {
+        "name" : "parasite_speciesLevel",
+        "titles" : "parasite_speciesLevel",
+        "datatype" : "string"
+      }, {
+        "name" : "parasite_IsZonotic",
+        "titles" : "parasite_IsZonotic",
+        "datatype" : "string"
+      }, {
+        "name" : "parasite_nbStudies",
+        "titles" : "parasite_nbStudies",
+        "datatype" : "string"
+      } ]
+    }
+  } ]
+}

--- a/globi.json
+++ b/globi.json
@@ -13,6 +13,7 @@
     "delimiter" : ";",
     "interactionTypeName": "parasiteOf",
     "interactionTypeId": "http://purl.obolibrary.org/obo/RO_0002444",
+    "targetTaxonName": "Lissachatina fulica",
     "headerRowCount" : 1,
     "null" : [ "" ],
     "tableSchema" : {


### PR DESCRIPTION
Hi @JGippet -

Congratulations on your recent publication - 

Gippet, J.M.W., Bates, O.K., Moulin, J. et al. The global risk of infectious disease emergence from giant land snail invasion and pet trade. Parasites Vectors 16, 363 (2023). https://doi.org/10.1186/s13071-023-06000-y

This pull requests contains configuration for GloBI to index data associated the publication.

By accepting this pull request, this dataset will be included in GloBI's indexed species interaction datasets. In addition to having the data be searchable via GloBI's website, API, rglobi, it'll be included in the derived data products available via https://globalbioticinteractions.org/data . 

Also, GloBI data reviews will be made available. I've attached a sample extracted from attached review-report.zip accessed via https://github.com/jhpoelen/Gippet2023_GiantLandSnails/suites/17371206513/artifacts/992704830 .

[review-report.zip](https://github.com/JGippet/Gippet2023_GiantLandSnails/files/13033909/review-report.zip)

[index.pdf](https://github.com/JGippet/Gippet2023_GiantLandSnails/files/13033913/index.pdf)
[index.docx](https://github.com/JGippet/Gippet2023_GiantLandSnails/files/13033916/index.docx)

Please let me know if you are interested to hear feedback on your dataset.

Also, am curious to hear any questions / comments that you may have.

-jorrit
https://jhpoelen.nl